### PR TITLE
Added null check since Oomph can not set the properties on repositories

### DIFF
--- a/de.weingardt.mylyn.gitlab.core/src/de/weingardt/mylyn/gitlab/core/ConnectionManager.java
+++ b/de.weingardt.mylyn.gitlab.core/src/de/weingardt/mylyn/gitlab/core/ConnectionManager.java
@@ -51,7 +51,7 @@ public class ConnectionManager {
 			String password= repository.getCredentials(AuthenticationType.REPOSITORY).getPassword();
 			
 			GitlabSession session = null;
-			if(repository.getProperty("usePrivateToken").equals("true")) {
+			if(repository.getProperty("usePrivateToken") != null && repository.getProperty("usePrivateToken").equals("true")) {
 				session = GitlabAPI.connect(host,  password).getCurrentSession();
 			} else {
 				session = GitlabAPI.connect(host, username, password);


### PR DESCRIPTION
Fixes issue #25 by checking if property "usePrivateToken". If null: uses else branch.