### PR TITLE
Retrieve only user's projects, not every project on the server.

### DIFF
--- a/de.weingardt.mylyn.gitlab.core/src/de/weingardt/mylyn/gitlab/core/ConnectionManager.java
+++ b/de.weingardt.mylyn.gitlab.core/src/de/weingardt/mylyn/gitlab/core/ConnectionManager.java
@@ -122,7 +122,7 @@ public class ConnectionManager {
 				projectPath = projectPath.substring(0, projectPath.length() - 4);
 			}
 
-			List<GitlabProject> projects = api.getProjects();
+			List<GitlabProject> projects = api.getMembershipProjects();
 			for(GitlabProject p : projects) {
 				if(p.getPathWithNamespace().equals(projectPath)) {
 					GitlabConnection connection = new GitlabConnection(host, p, token,


### PR DESCRIPTION
Opening this given the discussion in #56  (and, iirc, other reports). 

Caveat: I'm not entirely sure that the logic applies to all situations (though imo, it's the only sane approach to using gitlab.com).  If you're on a private server.... is there a use case for retrieving projects you're not part of?     If so, it probably needs some logic to pick which call to use, either based on if it's gitlab.com or not, or have a user checkbox or something. 